### PR TITLE
Update jail check to work with FreeBSD 13.0 and later

### DIFF
--- a/check_freebsd_version
+++ b/check_freebsd_version
@@ -138,8 +138,8 @@ check_freebsd_updates ()
     latest_patch_release=`openssl rsautl -pubin -inkey /tmp/pub.ssl.$$ -verify < /tmp/latest.ssl.$$ | awk -F '|' '{print $4}'`
   else
     version=`echo $release | awk -F '-' '{print $1}'`
-    svn_address="http://svn.freebsd.org/base/releng/$version/sys/conf/newvers.sh"
-    branch=`fetch -qo - $svn_address | grep BRANCH | head -1 | awk -F '"' '{print $2}'`
+    cgit_address="https://cgit.freebsd.org/src/plain/sys/conf/newvers.sh?h=releng/$version"
+    branch=`fetch -qo - $cgit_address | grep 'BRANCH=' | head -1 | awk -F '"' '{print $2}'`
     if [ `echo $branch | grep 'p'` ]; then
       latest_patch_release=`echo $branch | awk -F 'p' '{print $2}'`
     else


### PR DESCRIPTION
Hey there, here's a proposed fix to your `check_freebsd_version` plugin--in case you're interested!

This PR makes the following changes to the check within a jail:
1. Get the source from cgit.freebsd.org instead of svn.freebsd.org (which is no longer updated).
2. Correctly parse changes to the newvers.sh file in FreeBSD 13.0 and later.

I've tested against FreeBSD 12 and 13, but it should work on older versions too.